### PR TITLE
fix: fix page switching error

### DIFF
--- a/src/labeler/hooks/useVirtualizer.ts
+++ b/src/labeler/hooks/useVirtualizer.ts
@@ -110,7 +110,7 @@ const useScrollTracker = (containerRef: React.MutableRefObject<HTMLDivElement>) 
         setScrollTop(containerRef.current.scrollTop);
         containerRef.current.addEventListener('scroll', onScroll);
 
-        return () => containerRef.current.removeEventListener('scroll', onScroll);
+        return () => containerRef.current?.removeEventListener('scroll', onScroll);
     }, [containerRef]);
 
     return scrollTop;


### PR DESCRIPTION
Error will be reported after switching pages

TypeError: Cannot read properties of null (reading 'removeEventListener')

https://github.com/microsoft/react-text-annotator/issues/30