### PR TITLE
Fix dependency issue with newer react projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,15 @@
     "lodash.range": "^3.2.0",
     "mobx": "^5.13.0",
     "mobx-react": "^6.1.1",
-    "react": "^16.12.0",
-    "react-dom": "^16.8.6",
     "styled-components": "5.3.3",
     "ts-jest": "^29.0.3",
     "tslib": "^2.3.1",
     "typescript": "^4.4.4",
     "use-deep-compare-effect": "^1.8.1"
+  },
+  "peerDependencies": {
+    "react": ">=16.12.0",
+    "react-dom": ">=16.8.6"
   },
   "resolutions": {
     "@types/react": "^16.9.17",


### PR DESCRIPTION
react and react-dom were declared as a dependency instead of a peer dependency.

When integrating in a project with a newer react version (in my case 18), react breaks because of multiple versions used simultaneously.